### PR TITLE
add sass >=3.3 dependency

### DIFF
--- a/materialize-sass.gemspec
+++ b/materialize-sass.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  # development dependencies
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+
+  #runtime dependencies
+  spec.add_runtime_dependency "sass", ">=3.3"
 end


### PR DESCRIPTION
Added sass gem version >= 3.3 to runtime dependecies of materialize-sass gem
Solve #6 