### PR TITLE
Fix lighten not working in combination with a base-color when extending

### DIFF
--- a/app/assets/stylesheets/materialize/components/_color.scss
+++ b/app/assets/stylesheets/materialize/components/_color.scss
@@ -8,12 +8,12 @@
 
 
 $materialize-red: (
+  "base":       #e51c23,
   "lighten-5":  #fdeaeb,
   "lighten-4":  #f8c1c3,
   "lighten-3":  #f3989b,
   "lighten-2":  #ee6e73,
   "lighten-1":  #ea454b,
-  "base":       #e51c23,
   "darken-1":   #d0181e,
   "darken-2":   #b9151b,
   "darken-3":   #a21318,
@@ -21,12 +21,12 @@ $materialize-red: (
 );
 
 $red: (
+  "base":       #F44336,
   "lighten-5":  #FFEBEE,
   "lighten-4":  #FFCDD2,
   "lighten-3":  #EF9A9A,
   "lighten-2":  #E57373,
   "lighten-1":  #EF5350,
-  "base":       #F44336,
   "darken-1":   #E53935,
   "darken-2":   #D32F2F,
   "darken-3":   #C62828,
@@ -38,12 +38,12 @@ $red: (
 );
 
 $pink: (
+  "base":       #e91e63,
   "lighten-5":  #fce4ec,
   "lighten-4":  #f8bbd0,
   "lighten-3":  #f48fb1,
   "lighten-2":  #f06292,
   "lighten-1":  #ec407a,
-  "base":       #e91e63,
   "darken-1":   #d81b60,
   "darken-2":   #c2185b,
   "darken-3":   #ad1457,
@@ -55,12 +55,12 @@ $pink: (
 );
 
 $purple: (
+  "base":       #9c27b0,
   "lighten-5":  #f3e5f5,
   "lighten-4":  #e1bee7,
   "lighten-3":  #ce93d8,
   "lighten-2":  #ba68c8,
   "lighten-1":  #ab47bc,
-  "base":       #9c27b0,
   "darken-1":   #8e24aa,
   "darken-2":   #7b1fa2,
   "darken-3":   #6a1b9a,
@@ -72,12 +72,12 @@ $purple: (
 );
 
 $deep-purple: (
+  "base":       #673ab7,
   "lighten-5":  #ede7f6,
   "lighten-4":  #d1c4e9,
   "lighten-3":  #b39ddb,
   "lighten-2":  #9575cd,
   "lighten-1":  #7e57c2,
-  "base":       #673ab7,
   "darken-1":   #5e35b1,
   "darken-2":   #512da8,
   "darken-3":   #4527a0,
@@ -89,12 +89,12 @@ $deep-purple: (
 );
 
 $indigo: (
+  "base":       #3f51b5,
   "lighten-5":  #e8eaf6,
   "lighten-4":  #c5cae9,
   "lighten-3":  #9fa8da,
   "lighten-2":  #7986cb,
   "lighten-1":  #5c6bc0,
-  "base":       #3f51b5,
   "darken-1":   #3949ab,
   "darken-2":   #303f9f,
   "darken-3":   #283593,
@@ -106,12 +106,12 @@ $indigo: (
 );
 
 $blue: (
+  "base":       #2196F3,
   "lighten-5":  #E3F2FD,
   "lighten-4":  #BBDEFB,
   "lighten-3":  #90CAF9,
   "lighten-2":  #64B5F6,
   "lighten-1":  #42A5F5,
-  "base":       #2196F3,
   "darken-1":   #1E88E5,
   "darken-2":   #1976D2,
   "darken-3":   #1565C0,
@@ -123,12 +123,12 @@ $blue: (
 );
 
 $light-blue: (
+  "base":       #03a9f4,
   "lighten-5":  #e1f5fe,
   "lighten-4":  #b3e5fc,
   "lighten-3":  #81d4fa,
   "lighten-2":  #4fc3f7,
   "lighten-1":  #29b6f6,
-  "base":       #03a9f4,
   "darken-1":   #039be5,
   "darken-2":   #0288d1,
   "darken-3":   #0277bd,
@@ -140,12 +140,12 @@ $light-blue: (
 );
 
 $cyan: (
+  "base":       #00bcd4,
   "lighten-5":  #e0f7fa,
   "lighten-4":  #b2ebf2,
   "lighten-3":  #80deea,
   "lighten-2":  #4dd0e1,
   "lighten-1":  #26c6da,
-  "base":       #00bcd4,
   "darken-1":   #00acc1,
   "darken-2":   #0097a7,
   "darken-3":   #00838f,
@@ -157,12 +157,12 @@ $cyan: (
 );
 
 $teal: (
+  "base":       #009688,
   "lighten-5":  #e0f2f1,
   "lighten-4":  #b2dfdb,
   "lighten-3":  #80cbc4,
   "lighten-2":  #4db6ac,
   "lighten-1":  #26a69a,
-  "base":       #009688,
   "darken-1":   #00897b,
   "darken-2":   #00796b,
   "darken-3":   #00695c,
@@ -174,12 +174,12 @@ $teal: (
 );
 
 $green: (
+  "base":       #4CAF50,
   "lighten-5":  #E8F5E9,
   "lighten-4":  #C8E6C9,
   "lighten-3":  #A5D6A7,
   "lighten-2":  #81C784,
   "lighten-1":  #66BB6A,
-  "base":       #4CAF50,
   "darken-1":   #43A047,
   "darken-2":   #388E3C,
   "darken-3":   #2E7D32,
@@ -191,12 +191,12 @@ $green: (
 );
 
 $light-green: (
+  "base":       #8bc34a,
   "lighten-5":  #f1f8e9,
   "lighten-4":  #dcedc8,
   "lighten-3":  #c5e1a5,
   "lighten-2":  #aed581,
   "lighten-1":  #9ccc65,
-  "base":       #8bc34a,
   "darken-1":   #7cb342,
   "darken-2":   #689f38,
   "darken-3":   #558b2f,
@@ -208,12 +208,12 @@ $light-green: (
 );
 
 $lime: (
+  "base":       #cddc39,
   "lighten-5":  #f9fbe7,
   "lighten-4":  #f0f4c3,
   "lighten-3":  #e6ee9c,
   "lighten-2":  #dce775,
   "lighten-1":  #d4e157,
-  "base":       #cddc39,
   "darken-1":   #c0ca33,
   "darken-2":   #afb42b,
   "darken-3":   #9e9d24,
@@ -225,12 +225,12 @@ $lime: (
 );
 
 $yellow: (
+  "base":       #ffeb3b,
   "lighten-5":  #fffde7,
   "lighten-4":  #fff9c4,
   "lighten-3":  #fff59d,
   "lighten-2":  #fff176,
   "lighten-1":  #ffee58,
-  "base":       #ffeb3b,
   "darken-1":   #fdd835,
   "darken-2":   #fbc02d,
   "darken-3":   #f9a825,
@@ -242,12 +242,12 @@ $yellow: (
 );
 
 $amber: (
+  "base":       #ffc107,
   "lighten-5":  #fff8e1,
   "lighten-4":  #ffecb3,
   "lighten-3":  #ffe082,
   "lighten-2":  #ffd54f,
   "lighten-1":  #ffca28,
-  "base":       #ffc107,
   "darken-1":   #ffb300,
   "darken-2":   #ffa000,
   "darken-3":   #ff8f00,
@@ -259,12 +259,12 @@ $amber: (
 );
 
 $orange: (
+  "base":       #ff9800,
   "lighten-5":  #fff3e0,
   "lighten-4":  #ffe0b2,
   "lighten-3":  #ffcc80,
   "lighten-2":  #ffb74d,
   "lighten-1":  #ffa726,
-  "base":       #ff9800,
   "darken-1":   #fb8c00,
   "darken-2":   #f57c00,
   "darken-3":   #ef6c00,
@@ -276,12 +276,12 @@ $orange: (
 );
 
 $deep-orange: (
+  "base":       #ff5722,
   "lighten-5":  #fbe9e7,
   "lighten-4":  #ffccbc,
   "lighten-3":  #ffab91,
   "lighten-2":  #ff8a65,
   "lighten-1":  #ff7043,
-  "base":       #ff5722,
   "darken-1":   #f4511e,
   "darken-2":   #e64a19,
   "darken-3":   #d84315,
@@ -293,12 +293,12 @@ $deep-orange: (
 );
 
 $brown: (
+  "base":       #795548,
   "lighten-5":  #efebe9,
   "lighten-4":  #d7ccc8,
   "lighten-3":  #bcaaa4,
   "lighten-2":  #a1887f,
   "lighten-1":  #8d6e63,
-  "base":       #795548,
   "darken-1":   #6d4c41,
   "darken-2":   #5d4037,
   "darken-3":   #4e342e,
@@ -306,12 +306,12 @@ $brown: (
 );
 
 $blue-grey: (
+  "base":       #607d8b,
   "lighten-5":  #eceff1,
   "lighten-4":  #cfd8dc,
   "lighten-3":  #b0bec5,
   "lighten-2":  #90a4ae,
   "lighten-1":  #78909c,
-  "base":       #607d8b,
   "darken-1":   #546e7a,
   "darken-2":   #455a64,
   "darken-3":   #37474f,
@@ -319,12 +319,12 @@ $blue-grey: (
 );
 
 $grey: (
+  "base":       #9e9e9e,
   "lighten-5":  #fafafa,
   "lighten-4":  #f5f5f5,
   "lighten-3":  #eeeeee,
   "lighten-2":  #e0e0e0,
   "lighten-1":  #bdbdbd,
-  "base":       #9e9e9e,
   "darken-1":   #757575,
   "darken-2":   #616161,
   "darken-3":   #424242,


### PR DESCRIPTION
For example

```
div.card {
  @extend .lime, .lighten-5;
}
```

Will not work, but

```
div.card {
  @extend .lime, .darken-5;
}
```

will, because ```lighten``` ones are declared before ```base```-colors, while
```darken``` are declared after those, thus the base-colors overwrite the
lighten-colors.