### PR TITLE
Fix font-family names

### DIFF
--- a/app/assets/stylesheets/materialize/components/_roboto.scss
+++ b/app/assets/stylesheets/materialize/components/_roboto.scss
@@ -1,5 +1,5 @@
 @font-face {
-    font-family: "Roboto";
+    font-family: "Roboto-Thin";
     src: local(Roboto Thin),
         font-url("#{$roboto-font-path}Roboto-Thin.woff2") format("woff2"),
         font-url("#{$roboto-font-path}Roboto-Thin.woff") format("woff"),
@@ -7,7 +7,7 @@
     font-weight: 200;
 }
 @font-face {
-    font-family: "Roboto";
+    font-family: "Roboto-Light";
     src: local(Roboto Light),
         font-url("#{$roboto-font-path}Roboto-Light.woff2") format("woff2"),
         font-url("#{$roboto-font-path}Roboto-Light.woff") format("woff"),
@@ -26,7 +26,7 @@
 }
 
 @font-face {
-    font-family: "Roboto";
+    font-family: "Roboto-Medium";
     src: font-url("#{$roboto-font-path}Roboto-Medium.woff2") format("woff2"),
         font-url("#{$roboto-font-path}Roboto-Medium.woff") format("woff"),
         font-url("#{$roboto-font-path}Roboto-Medium.ttf") format("truetype");
@@ -34,7 +34,7 @@
 }
 
 @font-face {
-    font-family: "Roboto";
+    font-family: "Roboto-Bold";
     src: font-url("#{$roboto-font-path}Roboto-Bold.woff2") format("woff2"),
         font-url("#{$roboto-font-path}Roboto-Bold.woff") format("woff"),
         font-url("#{$roboto-font-path}Roboto-Bold.ttf") format("truetype");


### PR DESCRIPTION
Hello! Tried to use different Roboto font types and there weren't working properly. Noticed that it was just a minimal typo error and all names stayed as 'Roboto' and not the particular ones. I changed the names so they are usable. Thanks for working on this btw!