### PR TITLE
Add support for sprockets-rails 3 and sprockets 4.

### DIFF
--- a/lib/materialize-sass/engine.rb
+++ b/lib/materialize-sass/engine.rb
@@ -5,8 +5,11 @@ module Materialize
         %w(stylesheets javascripts fonts images).each do |sub|
           app.config.assets.paths << root.join('app/assets', sub).to_s
         end
-        app.config.assets.precompile << %r(material-design-icons/Material-Design-Icons\.(?:eot|svg|ttf|woff|woff2?)$)
-        app.config.assets.precompile << %r(roboto/Roboto-[\w-]+\.(?:eot|svg|ttf|woff|woff2?)$)
+
+        unless Sprockets::Rails::VERSION.starts_with?('3')
+          app.config.assets.precompile << %r(material-design-icons/Material-Design-Icons\.(?:eot|svg|ttf|woff|woff2?)$)
+          app.config.assets.precompile << %r(roboto/Roboto-[\w-]+\.(?:eot|svg|ttf|woff|woff2?)$)
+        end
       end
     end
   end


### PR DESCRIPTION
I'm using Rails 5 and this gem raises the following error on initial load.

`undefined method 'start_with?' for #<Regexp:0x007fd3cc286188>`

I took this fix from the following PR in another gem

https://github.com/twbs/bootstrap-sass/pull/965