### PR TITLE
Fix mobile dropdown

### DIFF
--- a/app/assets/javascripts/materialize/dropdown.js
+++ b/app/assets/javascripts/materialize/dropdown.js
@@ -201,7 +201,7 @@
           // If menu open, add click close handler to document
           if (activates.hasClass('active')) {
             $(document).bind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'), function (e) {
-              if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
+              if (!activates.is(e.target) && (!activates.find(e.target).length) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
                 hideDropdown();
                 $(document).unbind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'));
               }


### PR DESCRIPTION
I ran into an issue using mobile devices where dropdown's would close when trying to scroll within them. 

I was actually using the materialize selectors inside of a date picker control, which is probably why no one else seems to have encountered this issue before. 

This minor change fixes it, and I don't believe it should have any negative impacts. 

@mkhairi , if you could let me know how you handle these changes to the materialize source code; do I also submit a PR to the mainline materialize repo (https://github.com/Dogfalo/materialize)? Or do you pull any changes from here to there? 