### PR TITLE
Added default parameter to sass color function to make rendering the base color friendlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Since materialize color scheme are declared in color.scss you should import the 
 ```scss
 @import "materialize/components/color";
 $primary-color: color("blue", "lighten-2") !default;
+$secondary-color: color("yellow") !default;
 @import 'materialize';
 ```
 
@@ -69,7 +70,7 @@ For turbolinks 5 users
 
 For turbolinks classic users
 
-Add [`jquery-turbolinks`](https://github.com/kossnocorp/jquery.turbolinks) gem to Gemfile 
+Add [`jquery-turbolinks`](https://github.com/kossnocorp/jquery.turbolinks) gem to Gemfile
 
 ``` gem 'jquery-turbolinks' ```
 

--- a/app/assets/stylesheets/materialize/components/_color.scss
+++ b/app/assets/stylesheets/materialize/components/_color.scss
@@ -399,7 +399,7 @@ $colors: (
 // usage: color("name_of_color", "type_of_color")
 // to avoid to repeating map-get($colors, ...)
 
-@function color($color, $type) {
+@function color($color, $type: "base") {
   @if map-has-key($colors, $color) {
     $curr_color: map-get($colors, $color);
     @if map-has-key($curr_color, $type) {


### PR DESCRIPTION
I found when I wanted to use the basic colour from Materialize CSS, I had to look up the keyword for how to get it in the color.scss file. 

This change makes calling the base color easier and more obvious. I've also included an addition to the Readme to reflect this as well.