### PR TITLE
Fix README.md for `color` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Since materialize color scheme are declared in color.scss you should import the 
 ```scss
 @import "materialize/components/color";
 $primary-color: color("blue", "lighten-2") !default;
-$secondary-color: color("yellow") !default;
+$secondary-color: color("yellow", "base") !default;
 @import 'materialize';
 ```
 


### PR DESCRIPTION
To follow the latest original materialize API.
The `color` function has no default value.
see: https://github.com/Dogfalo/materialize/blob/v0.97.8/sass/components/_color.scss#L402