### PR TITLE
A flash message can be indicated for a toast.

### DIFF
--- a/app/assets/javascripts/materialize/toasts.js
+++ b/app/assets/javascripts/materialize/toasts.js
@@ -351,4 +351,10 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
   Materialize.toast = function (message, displayLength, className, completeCallback) {
     return new Toast(message, displayLength, className, completeCallback);
   };
+
+  Materialize.flash_message = function(flash_element, displayLength, className, completeCallback) {
+    var flash_message = $("." + flash_element);
+    var message = flash_message.text();
+    Materialize.toast(message, displayLength, className, completeCallback);
+  };
 })(jQuery, Materialize.Vel);

--- a/app/assets/stylesheets/materialize/components/_toast.scss
+++ b/app/assets/stylesheets/materialize/components/_toast.scss
@@ -57,3 +57,6 @@
     border-radius: 0;
   }
 }
+.flash_message{
+  display: none;
+}


### PR DESCRIPTION
# Purpose
I think Materialize.toast is very beautifully, functionally and conveniently.
I want to show the Flash messages on Materialize.toast.
because I created this PullRequest.

# Screen Shots
<img width="461" alt="2017-09-23 15 13 42" src="https://user-images.githubusercontent.com/7971341/30770706-2b0258ba-a072-11e7-9aa1-74bc3ce42b97.png">

<img width="486" alt="2017-09-23 15 15 49" src="https://user-images.githubusercontent.com/7971341/30770708-2d3b88b8-a072-11e7-9ee9-fd957b7f99f3.png">

# Approach
* Adds method in Materialize object
* hides notice element to use css from application.html.erb

# Usage
1, insert 'notice methods' in application.html.erb
```
# applcation.html.erb
<body>
  <%= yield %>
  <div class="flash_message"><%= notice %></div>
</body>
```

2, insert 'Materialize.flash_message' in application.js
```
# application.js
$(function(){
  // If you use callbacks. you can use it that same the Materialize.toast()
  Materialize.flash_message("flash_message", 3000);
});
```

Sorry for my poor English.
thank you for reading
