### PR TITLE
Fixed invalid property value of letter-spacing in table_of_contents

### DIFF
--- a/assets/stylesheets/materialize/components/_table_of_contents.scss
+++ b/assets/stylesheets/materialize/components/_table_of_contents.scss
@@ -16,7 +16,7 @@
     padding-left: 16px;
     height: 1.5rem;
     line-height: 1.5rem;
-    letter-spacing: .4;
+    letter-spacing: .4px;
     display: inline-block;
 
     &:hover {


### PR DESCRIPTION
Without a unit, there was a CSS error. I made an assumption that ".4px" was intended rather than ".4", based on the _buttons.scss letter-spacing being ".5px".