### PR TITLE
Fix Rails 6 zeitwork autoloading deprecation

### DIFF
--- a/lib/materialize-sass/engine.rb
+++ b/lib/materialize-sass/engine.rb
@@ -8,7 +8,10 @@ module Materialize
         %w(stylesheets javascripts).each do |sub|
           app.config.assets.paths << root.join('assets', sub).to_s
         end
-        ActionController::Base.send(:helper, Materialize::Helpers)
+
+        ActiveSupport.on_load(:action_controller_base) do
+          ActionController::Base.send(:helper, Materialize::Helpers)
+        end
       end
     end
   end


### PR DESCRIPTION
Including the gem in a Rails 6 app results in the following error message:
> DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.
> 
> Being able to do this is deprecated. Autoloading during initialization is going
> to be an error condition in future versions of Rails.

This change uses ActiveSupport's onload hook in order to ensure that the materialize helpers are added to the *newly loaded* ActionController::Base, whenever a reload occurs.

Fixes #192

- [ ] Works in older versions of rails?